### PR TITLE
[Feat] 알람창 컬러색 설정

### DIFF
--- a/Mac_Health/Page/Main/MainView.swift
+++ b/Mac_Health/Page/Main/MainView.swift
@@ -11,6 +11,7 @@ struct MainView: View {
     init() {
         UITabBar.appearance().backgroundColor = Color.tabbar_main
         UITabBar.appearance().unselectedItemTintColor = UIColor(Color.label_600)
+        UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = UIColor(Color.green_main)
     }
     
     var body: some View {

--- a/Mac_Health/Page/ProfileView/View/ManageSubscribeView.swift
+++ b/Mac_Health/Page/ProfileView/View/ManageSubscribeView.swift
@@ -41,7 +41,7 @@ struct ManageSubscribeView: View {
                     .foregroundColor(.label_900)
                 Spacer()
                 Button {
-                    self.cancelingSubscribed = true
+                    cancelingSubscribed.toggle()
                 } label: {
                     RoundedRectangle(cornerRadius: 20)
                         .frame(width: 76, height: 32)
@@ -52,16 +52,12 @@ struct ManageSubscribeView: View {
                                 .font(.button2())
                         }
                 }
-                .alert(isPresented: $cancelingSubscribed) {
-                    Alert(
-                        title: Text("구독을 취소하시겠습니까?"),
-        //                message: Text(""),
-                        primaryButton: .destructive(Text("확인"),
-                                                action: {
-
-                                        }),
-                                        secondaryButton: .cancel(Text("취소"))
-                    )
+                //TODO: 여기서 취소버튼누르면 네트워킹 쏴줘야함.
+                .alert("구독을 취소하시겠습니까?", isPresented: $cancelingSubscribed) {
+                    Button("취소") { }
+                    Button("확인") {
+                        
+                    }.bold()
                 }
             }
             


### PR DESCRIPTION
아 노트북 베터리 조루네 ㄷㄷ..
<img width="732" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Temp/assets/96717313/88ac5fe4-de34-4b6f-8b88-2581e79b12d1">

추가해서 앞으로 모든 알람창에 들어가는 button은 다 메인 컬러로 지정됨.

<img width="693" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-Booster-Temp/assets/96717313/2dabff6a-482c-430c-b747-ef0dc83ac730">

이런방식으로 쓰면 되고, 빨간색 넣고 싶을때는 role에 .cancle 넣어주시면 됩니다.

`
.alert("구독을 취소하시겠습니까?", isPresented: $cancelingSubscribed) {
                    Button("취소", role: .cancle ) { }
                }
`
이렇게요